### PR TITLE
chore: test npm next-12

### DIFF
--- a/.changeset/npm12-info-json-array.md
+++ b/.changeset/npm12-info-json-array.md
@@ -1,0 +1,14 @@
+---
+'@verdaccio/e2e-cli': patch
+---
+
+fix: support npm 12 in e2e-cli
+
+npm 12 wraps `npm info <pkg> --json` output in a single-element array instead of
+a bare object, which made the info, deprecate and install-multiple-deps tests read
+an `undefined` package name. Added a `normalizeInfo` helper that unwraps the array
+(backward-compatible with older npm).
+
+Also pin `min-release-age=0` in the generated project `.npmrc` so npm 12's new
+release-age cooldown — if set in a developer's global `~/.npmrc` — no longer rejects
+the freshly published packages the tests install.

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -23,6 +23,8 @@ jobs:
           - npm@8
           - npm@9
           - npm@10
+          - npm@11
+          - npm@next-12
           - pnpm@9
           - pnpm@10
           - pnpm@11.5.2

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        verdaccio: ['5', '6', 'next-7']
+        verdaccio: ['5', '6', 'next-7', 'next-9']
         pm:
           - npm@7
           - npm@8

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         verdaccio: ['5', '6', 'next-7', 'next-9']
         pm:
-          - npm@7
           - npm@8
           - npm@9
           - npm@10
@@ -27,10 +26,10 @@ jobs:
           - npm@next-12
           - pnpm@9
           - pnpm@10
-          - pnpm@11.5.2
+          - pnpm@11
           - yarn-classic
           - yarn-modern@3
-          - yarn-modern@4.16.0
+          - yarn-modern@4
           - bun
           - deno
     name: verdaccio@${{ matrix.verdaccio }} / ${{ matrix.pm }}

--- a/tools/e2e-cli/src/scenarios/install-multiple-deps.ts
+++ b/tools/e2e-cli/src/scenarios/install-multiple-deps.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import buildDebug from 'debug';
 
 import { TestContext, TestDefinition } from '../types';
+import { normalizeInfo } from '../utils/info';
 
 const debug = buildDebug('verdaccio:e2e-cli:scenario:install-multiple-deps');
 
@@ -40,9 +41,9 @@ function parseInfoOutput(stdout: string, adapterType: string): any {
       }
     }
     // Fallback: try parsing the whole output
-    return JSON.parse(stdout);
+    return normalizeInfo(JSON.parse(stdout));
   }
-  return JSON.parse(stdout);
+  return normalizeInfo(JSON.parse(stdout));
 }
 
 async function publishSeedPackage(

--- a/tools/e2e-cli/src/tests/deprecate.ts
+++ b/tools/e2e-cli/src/tests/deprecate.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 
 import { TestContext, TestDefinition } from '../types';
+import { parseInfoJson } from '../utils/info';
 
 const debug = buildDebug('verdaccio:e2e-cli:test:deprecate');
 
@@ -49,7 +50,7 @@ async function getInfo(ctx: TestContext, tempFolder: string, pkgName: string) {
     '--json',
     ...ctx.adapter.registryArg(ctx.registryUrl)
   );
-  const parsed = JSON.parse(resp.stdout);
+  const parsed = parseInfoJson(resp.stdout);
   debug('info for %s: deprecated=%s', pkgName, parsed.deprecated ?? '(not set)');
   return parsed;
 }

--- a/tools/e2e-cli/src/tests/info.ts
+++ b/tools/e2e-cli/src/tests/info.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'fs/promises';
 import { join } from 'path';
 
 import { TestContext, TestDefinition } from '../types';
+import { parseInfoJson } from '../utils/info';
 import { createTempFolder } from '../utils/project';
 
 async function testInfo(ctx: TestContext): Promise<void> {
@@ -38,7 +39,7 @@ async function testInfo(ctx: TestContext): Promise<void> {
     const output = resp.stdout + resp.stderr;
     assert.ok(output.includes('verdaccio'), 'Expected deno info output to reference verdaccio');
   } else {
-    const parsedBody = JSON.parse(resp.stdout);
+    const parsedBody = parseInfoJson(resp.stdout);
     assert.strictEqual(parsedBody.name, 'verdaccio', 'Expected package name "verdaccio"');
     assert.ok(parsedBody.dependencies !== undefined, 'Expected "dependencies" to be defined');
   }

--- a/tools/e2e-cli/src/utils/index.ts
+++ b/tools/e2e-cli/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { exec, setVerbose } from './process';
 export { createTempFolder, getPackageJSON, getREADME, prepareGenericEmptyProject } from './project';
 export { createUser, pingRegistry } from './registry-client';
+export { normalizeInfo, parseInfoJson } from './info';

--- a/tools/e2e-cli/src/utils/info.ts
+++ b/tools/e2e-cli/src/utils/info.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalize the parsed output of `npm/pnpm info <pkg> --json`.
+ *
+ * npm 12+ wraps the result in a single-element JSON array
+ * (e.g. `[{ "name": "verdaccio", ... }]`) for both full-packument and
+ * version-specific queries, whereas older npm versions return a bare object.
+ * When multiple results match a range, the array holds one entry per match;
+ * the last entry is the highest (latest) version, which is what the tests want.
+ *
+ * Returns the bare object as-is for backward compatibility.
+ */
+export function normalizeInfo(parsed: any): any {
+  if (Array.isArray(parsed)) {
+    return parsed[parsed.length - 1];
+  }
+  return parsed;
+}
+
+/** Parse `info --json` stdout and normalize to a single info object. */
+export function parseInfoJson(stdout: string): any {
+  return normalizeInfo(JSON.parse(stdout));
+}

--- a/tools/e2e-cli/src/utils/project.ts
+++ b/tools/e2e-cli/src/utils/project.ts
@@ -58,8 +58,13 @@ export async function prepareGenericEmptyProject(
   devDependencies: Record<string, string> = {}
 ): Promise<{ tempFolder: string }> {
   debug('preparing generic project %o', packageName);
+  // `min-release-age=0` keeps the harness hermetic: npm 12 added a release-age
+  // cooldown that, if set in the developer's global ~/.npmrc, would reject the
+  // just-published packages these tests install (ETARGET / "no matching version
+  // ... before <date>"). Pinning it per-project overrides any global value.
+  // It's an npm-only key — pnpm (minimum-release-age) and yarn ignore it.
   const getNPMrc = (port: number, token: string, registry: string) =>
-    `//localhost:${port}/:_authToken=${token}\nregistry=${registry}`;
+    `//localhost:${port}/:_authToken=${token}\nregistry=${registry}\nmin-release-age=0`;
   const tempFolder = await createTempFolder('temp-folder');
   await writeFile(
     join(tempFolder, 'package.json'),


### PR DESCRIPTION
## Summary

Adds npm 12 to the e2e test matrix and makes the CLI test harness compatible with npm 12's behavior changes.

- Adds `npm@next-12` (and `npm@11`) to the package-manager matrix, plus `next-9` to the verdaccio matrix.
- Cleans up matrix entries: drops EOL `npm@7`, and floats pinned versions (`pnpm@11.5.2` → `pnpm@11`, `yarn-modern@4.16.0` → `yarn-modern@4`).
- Introduces a shared `normalizeInfo` / `parseInfoJson` helper (`tools/e2e-cli/src/utils/info.ts`) used by the `info`, `deprecate`, and `install-multiple-deps` tests.
- Pins `min-release-age=0` in the generated project `.npmrc` to keep the harness hermetic under npm 12.

## Differences found while implementing npm 12 support

**1. `npm info <pkg> --json` now returns an array.**
npm 12 wraps the output of `npm info --json` in a single-element JSON array (e.g. `[{ "name": "verdaccio", ... }]`) for both full-packument and version-specific queries, whereas older npm returned a bare object. This caused tests to read `undefined` for the package name (`parsedBody.name`, `parsed.deprecated`, etc.).

Fix: a `normalizeInfo` helper unwraps the array — returning the **last** entry (the highest/latest version when a range matches multiple) — and falls back to returning the object as-is for older npm, so it's backward-compatible across the whole matrix.

**2. npm 12 added a release-age cooldown.**
npm 12 introduced a `min-release-age` setting. If a developer has it set in their global `~/.npmrc`, npm refuses to install the packages these tests *just* published (failing with `ETARGET` / "no matching version found ... before `<date>`"), because they're younger than the cooldown window.

Fix: pin `min-release-age=0` in the per-project `.npmrc` generated by `prepareGenericEmptyProject`, which overrides any global value. It's an npm-only key — pnpm (`minimum-release-age`) and yarn ignore it, so other package managers in the matrix are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
